### PR TITLE
Fixing isOccupied function in Square class

### DIFF
--- a/js/square.js
+++ b/js/square.js
@@ -9,6 +9,6 @@ Square.prototype.setSymbol = function(value){
 };
 
 //To check square has symbol
-Square.prototype.isOccupied(){
+Square.prototype.isOccupied = function(){
     return this.symbol ? true : false;
 }


### PR DESCRIPTION
There was a problem with **isOccupied** method em `square.js`. The function was typed as below:
```js
Square.prototype.isOccupied(){
    return this.symbol ? true : false;
}
```
Insted of:

```js
Square.prototype.isOccupied = function(){
    return this.symbol ? true : false;
}
```